### PR TITLE
HD-112629 Platform > anytv-i18n > Fix config loading

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,8 +3,9 @@
   "plugins": [
     "json"
   ],
+  "parser": "babel-eslint", 
   "parserOptions": {
-    "ecmaVersion": 2018,
+    "ecmaVersion": 2020,
     "sourceType": "module",
     "impliedStrict": true
   },

--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,5 @@ package-lock.json
 trash
 sblm.sublime-workspace
 
-_locales/*.json
-
 /index.js
 .idea

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ const i18n = require('anytv-18n');
 i18n.configure({
     languages_url: 'http://translations.myapp.com/:project/languages',
     translations_url: 'http://translations.myapp.com/:project/:lang.json',
-    locales_dir: '/../../translations',
+    locale_dir: '_locales',
     default: 'en',
     debug: true
 });

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ const i18n = require('anytv-18n');
 i18n.configure({
     languages_url: 'http://translations.myapp.com/:project/languages',
     translations_url: 'http://translations.myapp.com/:project/:lang.json',
-    locales_dir: '_locales',
+    locales_dir: '/../../translations',
     default: 'en',
     debug: true
 });
@@ -66,7 +66,7 @@ i18n.use('freedom_dashboard')
 }
 ```
 
-* `locale_dir` directory where the translations will be cached. should be an absolute path with a trailing backslach. example: `/home/user/my-app/_locales/`
+* `locale_dir` directory where the translations will be cached. should be an absolute path with a trailing backslach. example: `/home/user/my-app/translations/`
 * `debug` set to true if you want to debug
 * `logger` replaces the default logger
   > note: Only [Winston](https://github.com/winstonjs/winston)-like loggers are accepted

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ const i18n = require('anytv-18n');
 i18n.configure({
     languages_url: 'http://translations.myapp.com/:project/languages',
     translations_url: 'http://translations.myapp.com/:project/:lang.json',
-    locale_dir: '_locales',
+    locale_dir: path.resolve('translations'),
     default: 'en',
     debug: true
 });

--- a/package.json
+++ b/package.json
@@ -30,7 +30,8 @@
     "start": "grunt",
     "build": "grunt build",
     "test": "grunt test",
-    "test-dev": "export NODE_ENV=test && mocha --watch --recursive -R spec -t 5000 -s 100"
+    "test-dev": "export NODE_ENV=test && mocha --watch --recursive -R spec -t 5000 -s 100",
+    "prepare": "grunt build"
   },
   "files": [
     "LICENSE",

--- a/package.json
+++ b/package.json
@@ -35,8 +35,7 @@
   "files": [
     "LICENSE",
     "README.md",
-    "index.js",
-    "_locales/.gitkeep"
+    "index.js"
   ],
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "files": [
     "LICENSE",
     "README.md",
-    "index.js"
+    "index.js",
+    "translations/.gitkeep"
   ],
   "repository": {
     "type": "git",

--- a/src/classes/i18n.js
+++ b/src/classes/i18n.js
@@ -26,7 +26,8 @@ export default class i18n {
         this.loaded = false;
 
         this.config = new Config();
-        this.locales_folder = '';
+        this.locale_folder = path.normalize(this.config.get('locale_dir'));
+        this.ensure_dir_existence(this.locale_folder);
 
         this.prefix = 'i18n ::';
         this.debug = logger.debug.bind(logger, this.prefix);
@@ -56,11 +57,8 @@ export default class i18n {
             logger.use(cfg.logger);
         }
 
-        this.locales_folder = path.normalize(this.config.get('locale_dir'));
-
-        if (!fs.existsSync(this.locales_folder)){
-            fs.mkdirSync(this.locales_folder, { recursive: true });
-        }
+        this.locale_folder = path.normalize(this.config.get('locale_dir'));
+        this.ensure_dir_existence(this.locale_folder);
 
         this.debug('configuration done', cfg);
 
@@ -162,7 +160,7 @@ export default class i18n {
 
     load_files (cb) {
 
-        this.translations = importer.dirloadSync(this.locales_folder);
+        this.translations = importer.dirloadSync(this.locale_folder);
         this.debug('from files', Object.keys(this.translations));
 
         this.loaded = true;
@@ -203,7 +201,7 @@ export default class i18n {
         const url = this.translations_url.replace(':lang', lang) + random_str;
 
 
-        const translation_file_path = path.join([this.locales_folder, lang + '.json']);
+        const translation_file_path = path.join([this.locale_folder, lang + '.json']);
 
         for (let retry = 0; retry < MAX_RETRY; retry++) {
             if (process.env.REFRESH_TRANSLATIONS
@@ -261,5 +259,11 @@ export default class i18n {
             file_handle.on('finish', () => resolve());
         });
 
+    }
+
+    ensure_dir_existence(dir_path) {
+        if (!fs.existsSync(dir_path)){
+            fs.mkdirSync(dir_path, { recursive: true });
+        }
     }
 }

--- a/src/classes/i18n.js
+++ b/src/classes/i18n.js
@@ -27,7 +27,6 @@ export default class i18n {
 
         this.config = new Config();
         this.locale_folder = path.resolve(this.config.get('locale_dir'));
-        this.ensure_dir_existence(this.locale_folder);
 
         this.prefix = 'i18n ::';
         this.debug = logger.debug.bind(logger, this.prefix);

--- a/src/classes/i18n.js
+++ b/src/classes/i18n.js
@@ -26,7 +26,7 @@ export default class i18n {
         this.loaded = false;
 
         this.config = new Config();
-        this.locale_folder = path.normalize(this.config.get('locale_dir'));
+        this.locale_folder = path.resolve(this.config.get('locale_dir'));
         this.ensure_dir_existence(this.locale_folder);
 
         this.prefix = 'i18n ::';
@@ -57,7 +57,7 @@ export default class i18n {
             logger.use(cfg.logger);
         }
 
-        this.locale_folder = path.normalize(this.config.get('locale_dir'));
+        this.locale_folder = path.resolve(this.config.get('locale_dir'));
         this.ensure_dir_existence(this.locale_folder);
 
         this.debug('configuration done', cfg);
@@ -201,7 +201,7 @@ export default class i18n {
         const url = this.translations_url.replace(':lang', lang) + random_str;
 
 
-        const translation_file_path = path.join([this.locale_folder, lang + '.json']);
+        const translation_file_path = path.resolve(path.join(this.locale_folder, lang + '.json'));
 
         for (let retry = 0; retry < MAX_RETRY; retry++) {
             if (process.env.REFRESH_TRANSLATIONS

--- a/src/config.js
+++ b/src/config.js
@@ -1,4 +1,6 @@
-var locale_dir = __dirname + '_locales';
+import path from 'path';
+
+const locale_dir = path.resolve(path.dirname(require.main.filename), 'translations');
 
 export default {
     default: 'en',

--- a/src/config.js
+++ b/src/config.js
@@ -1,8 +1,13 @@
+var fs = require('fs');
+var dir = __dirname + '/../../translations/';
 
+if (!fs. existsSync(dir)){
+    fs. mkdirSync(dir);
+}
 
 export default {
     default: 'en',
-    locale_dir: __dirname + '/../_locales/',
+    locale_dir: dir,
 
     download_retry: 3,
     service_version: 'latest',

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,6 @@
 import path from 'path';
 
-const locale_dir = path.resolve(path.dirname(require.main.filename), 'translations');
+const locale_dir = path.resolve(path.join('node_modules', 'anytv-i18n', 'translations'));
 
 export default {
     default: 'en',

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,9 @@
-import path from 'path';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
 
-const locale_dir = path.resolve(path.join('node_modules', 'anytv-i18n', 'translations'));
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const locale_dir = resolve(__dirname, 'translations');
 
 export default {
     default: 'en',

--- a/src/config.js
+++ b/src/config.js
@@ -1,14 +1,8 @@
-var fs = require('fs');
-var dir = __dirname + '/../../translations/';
-
-if (!fs. existsSync(dir)){
-    fs. mkdirSync(dir);
-}
+var locale_dir = __dirname + '_locales';
 
 export default {
     default: 'en',
-    locale_dir: dir,
-
+    locale_dir,
     download_retry: 3,
     service_version: 'latest',
 };

--- a/test/config.js
+++ b/test/config.js
@@ -1,9 +1,15 @@
+var fs = require('fs');
+var dir = __dirname + '/../../translations/';
+
+if (!fs. existsSync(dir)){
+    fs. mkdirSync(dir);
+}
 
 
 export default {
     languages_url: 'http://translations.tm/:project/languages',
     translations_url: 'http://translations.tm/:project/:lang.json',
-    locales_dir: __dirname + '/../_locales',
+    locales_dir: dir,
     project: 'test_project',
     default: 'en'
 };

--- a/test/config.js
+++ b/test/config.js
@@ -1,5 +1,5 @@
 import path from 'path';
-const locale_dir = path.resolve(path.dirname(require.main.filename), 'translations');
+const locale_dir = path.resolve(path.join('node_modules', 'anytv-i18n', 'translations'));
 
 export default {
     languages_url: 'http://translations.tm/:project/languages',

--- a/test/config.js
+++ b/test/config.js
@@ -1,15 +1,9 @@
-var fs = require('fs');
-var dir = __dirname + '/../../translations/';
-
-if (!fs. existsSync(dir)){
-    fs. mkdirSync(dir);
-}
-
+var locale_dir = __dirname + '_locales';
 
 export default {
     languages_url: 'http://translations.tm/:project/languages',
     translations_url: 'http://translations.tm/:project/:lang.json',
-    locales_dir: dir,
+    locale_dir,
     project: 'test_project',
     default: 'en'
 };

--- a/test/config.js
+++ b/test/config.js
@@ -1,5 +1,9 @@
-import path from 'path';
-const locale_dir = path.resolve(path.join('node_modules', 'anytv-i18n', 'translations'));
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const locale_dir = resolve(__dirname, 'translations');
 
 export default {
     languages_url: 'http://translations.tm/:project/languages',

--- a/test/config.js
+++ b/test/config.js
@@ -1,4 +1,5 @@
-var locale_dir = __dirname + '_locales';
+import path from 'path';
+const locale_dir = path.resolve(path.dirname(require.main.filename), 'translations');
 
 export default {
     languages_url: 'http://translations.tm/:project/languages',


### PR DESCRIPTION
<!--
Title your pull request with the following:
    <ticket-id> <ticket-name>

If your pull request is not yet ready for reviewing*:
    [WIP] <ticket-id> <ticket-name>

If your pull request should be ignored by the CI but is ready for reviewing*:
    [CI SKIP] <ticket-id> <ticket-name>

*Note that the CI will ignore pull requests with either "[WIP]",
"[CI SKIP]", or "[SKIP CI]" on the PR title (case insensitive).
-->

## Ticket references
- [HD-112629 Platform > anytv-i18n > Fix config loading](https://freedom.myjetbrains.com/youtrack/issue/HD-112629)

## Summary of changes
<!--
Describe the change and why it was introduced. Ideally, this will also be
used as the commit message when we do squash merge.

This is better presented in paragraph form. Only use bullet form when
enumerating specific parts of the change.

Include screenshots, if possible.
-->

## Checklist
<!--
 Mark the things that have been followed.
-->
- [ ] bugfix
- [ ] new feature
- [ ] breaking change
- [ ] added unit tests
- [ ] changes introduced has been discussed and approved
- [ ] requires manual testing
- [ ] documentation has been updated

## Testing
<!--
Include this if we need manual testing and not a unit test.
If the tests do not reach 10 lines, add it here, else move it to a document and link it to this section.
-->


## Testing
<!--
    Include this if we need manual testing and not a unit test.
    If the tests do not reach 10 lines, add it here, else move it to a document and link it to this section.
-->
To use the translation:
1. clone this local and checkout branch `HD-112629-fix-i18n-config`
2. in content-id-service, apply patch from https://gist.githubusercontent.com/wilbertverayin/1bdca84e09250c7441f18d332f8b6b54/raw/1c14982627ce2850d1ec817f9c48a51898e24cbe/diff.path

3. in anytv-i18n, call `npm run build`
![image](https://user-images.githubusercontent.com/4616594/133051700-38e97f91-344c-4dc9-8061-c05cf7f8ece9.png)

4. in content-id-service run `grunt`
5. It should run without looking for _locale now
![image](https://user-images.githubusercontent.com/4616594/133051610-b25ddef0-4a07-4ec4-ab83-815806ebf023.png)
6. access localhost:9000/not-found
should show translated
![image](https://user-images.githubusercontent.com/4616594/133193506-027c8100-a680-4b97-acba-56520ec15fdf.png)

Commands used:
```
cd projects
git clone https://github.com/anyTV/anytv-i18n.git
cd anytv-i18n
git checkout HD-112629-fix-i18n-config
npm i
npm run build
cd ../content-id-service
git checkout master
curl https://gist.githubusercontent.com/wilbertverayin/1bdca84e09250c7441f18d332f8b6b54/raw/1c14982627ce2850d1ec817f9c48a51898e24cbe/diff.path > diff.patch | git apply diff.patch
rm -rf node_modules && npm i ../anytv-i18n && npm i
grunt
on another terminal
curl 'http://localhost:9000/not-found'
```
