### PR TITLE
HD-112781 Aegis claims sync/ 2 November 2021

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ sblm.sublime-workspace
 
 /index.js
 .idea
+
+translations

--- a/.gitignore
+++ b/.gitignore
@@ -22,4 +22,4 @@ sblm.sublime-workspace
 /index.js
 .idea
 
-translations
+translations/*.json

--- a/src/classes/i18n.js
+++ b/src/classes/i18n.js
@@ -211,6 +211,7 @@ export default class i18n {
 
             languages = response.data;
 
+            // save LANGUAGES.json file
             await fs_promises.writeFile(
                 this.languages_path,
                 JSON.stringify(languages)


### PR DESCRIPTION
<!--
Title your pull request with the following:
    <ticket-id> <ticket-name>

If your pull request is not yet ready for reviewing*:
    [WIP] <ticket-id> <ticket-name>

If your pull request should be ignored by the CI but is ready for reviewing*:
    [CI SKIP] <ticket-id> <ticket-name>

*Note that the CI will ignore pull requests with either "[WIP]",
"[CI SKIP]", or "[SKIP CI]" on the PR title (case insensitive).
-->

## Ticket references
- [HD-112781 Aegis claims sync/ 2 November 2021](https://freedom.myjetbrains.com/youtrack/issue/HD-112781)

## Summary of changes
<!--
Describe the change and why it was introduced. Ideally, this will also be
used as the commit message when we do squash merge.

This is better presented in paragraph form. Only use bullet form when
enumerating specific parts of the change.

Include screenshots, if possible.
-->
* feat: prevent network activity every time

## Checklist
<!--
 Mark the things that have been followed.
-->
- [ ] bugfix
- [x] new feature
- [ ] breaking change
- [ ] added unit tests
- [ ] changes introduced has been discussed and approved
- [ ] requires manual testing
- [ ] documentation has been updated

## Testing
<!--
Include this if we need manual testing and not a unit test.
If the tests do not reach 10 lines, add it here, else move it to a document and link it to this section.
-->
### Install in CID
* `rm -rf node_modules/anytv-i18n`
* `npm i https://github.com/anyTV/anytv-i18n.git#feat/load-langauges-from-file`

### Test that the module still creates `translations` folder
* `node server`
* check that `node_modules/anytv-i18n/translations` exists
```
---> file node_modules/anytv-i18n/translations
node_modules/anytv-i18n/translations: directory
```

### Test that the module writes `meta.json`
* `node server`
* check that `node_modules/anytv-i18n/translations/meta.json` contains the version in aegis' package.json
```
---> cat package.json | grep version
  "version": "1.50.3",

---> cat node_modules/anytv-i18n/translations/meta.json |  grep -Eo "version.*"
1.50.3

```

### Test that the module will redownload on version mismatch
* change the content of `node_modules/anytv-i18n/translations/meta.json` to something else
```
sed -i 's/1.50.2/1.50.3/' node_modules/anytv-i18n/translations/meta.json
```
* remove `node_modules/anytv-i18n/translations/en.json`
```
rm node_modules/anytv-i18n/translations/en.json
```
* `node server`
* `node_modules/anytv-i18n/translations/en.json` should be downloaded
```
file node_modules/anytv-i18n/translations/en.json
```
* check that `node_modules/anytv-i18n/translations/meta.json` contains the version in aegis' package.json
```
---> cat package.json | grep version
  "version": "1.50.3",

---> cat node_modules/anytv-i18n/translations/meta.json |  grep -Eo "version.*"
1.50.3

```

### Test that the module will not fetch from API if meta.json exists
* update meta.json
```
echo '{"languages":["ru","nl"], "version": "1.50.3"}' > node_modules/anytv-i18n/translations/meta.json
```
* remove other translations
```
cd node_modules/anytv-i18n/translations
rm -f af.json es.json sq.json ar.json fr.json nl.json th.json de.json hi.json pt.json en.json ru.json zh_TW.json
```
* there should be no translations downloaded